### PR TITLE
fix: Creates a new order if none exists

### DIFF
--- a/client/components/Order.js
+++ b/client/components/Order.js
@@ -4,6 +4,7 @@ import {
   fetchCurrentOrder,
   purchaseOrder,
   deleteCartItem,
+  updateQty,
 } from '../store/currentOrder';
 import SingleCart from './SingleCart';
 
@@ -32,6 +33,7 @@ class Order extends React.Component {
                 }}
                 deleteCartItem={this.props.deleteCartItem}
                 update={this.props.updateCartItemQty}
+                userId={this.props.match.params.userId}
                 key={cur.id}
               />,
             ];
@@ -70,7 +72,7 @@ const mapDispatchToProps = (dispatch) => ({
   getOrder: (userId) => dispatch(fetchCurrentOrder(userId)),
   deleteCartItem: (cartItemId, userId) =>
     dispatch(deleteCartItem(cartItemId, userId)),
-  updateCartItemQty: (qtyObj) => dispatch(updateQty(qtyObj)),
+  updateCartItemQty: (qtyObj, userId) => dispatch(updateQty(qtyObj, userId)),
   purchaseOrder: (orderId, userId) => dispatch(purchaseOrder(orderId, userId)),
 });
 export default connect(mapStateToProps, mapDispatchToProps)(Order);

--- a/client/components/SingleCart.js
+++ b/client/components/SingleCart.js
@@ -23,10 +23,13 @@ class SingleCart extends React.Component {
           max={product.maxQuantity}
           onChange={(evt) => {
             this.setState({ quantity: parseInt(evt.target.value) });
-            this.props.update({
-              cartItemId: this.state.cartItemId,
-              quantity: parseInt(evt.target.value),
-            });
+            this.props.update(
+              {
+                cartItemId: this.state.cartItemId,
+                quantity: parseInt(evt.target.value),
+              },
+              this.props.userId
+            );
           }}
         />
         <button

--- a/client/store/auth.js
+++ b/client/store/auth.js
@@ -1,60 +1,62 @@
-import axios from 'axios'
-import history from '../history'
+import axios from 'axios';
+import history from '../history';
 
-const TOKEN = 'token'
+const TOKEN = 'token';
 
 /**
  * ACTION TYPES
  */
-const SET_AUTH = 'SET_AUTH'
+const SET_AUTH = 'SET_AUTH';
 
 /**
  * ACTION CREATORS
  */
-const setAuth = auth => ({type: SET_AUTH, auth})
+const setAuth = (auth) => ({ type: SET_AUTH, auth });
 
 /**
  * THUNK CREATORS
  */
-export const me = () => async dispatch => {
-  const token = window.localStorage.getItem(TOKEN)
+export const me = () => async (dispatch) => {
+  const token = window.localStorage.getItem(TOKEN);
   if (token) {
     const res = await axios.get('/auth/me', {
       headers: {
-        authorization: token
-      }
-    })
-    return dispatch(setAuth(res.data))
+        authorization: token,
+      },
+    });
+    return dispatch(setAuth(res.data));
   }
-}
+};
 
-export const authenticate = (username, password, method) => async dispatch => {
-  try {
-    const res = await axios.post(`/auth/${method}`, {username, password})
-    window.localStorage.setItem(TOKEN, res.data.token)
-    dispatch(me())
-  } catch (authError) {
-    return dispatch(setAuth({error: authError}))
-  }
-}
+export const authenticate =
+  (username, password, method) => async (dispatch) => {
+    try {
+      const res = await axios.post(`/auth/${method}`, { username, password });
+      window.localStorage.setItem(TOKEN, res.data.token);
+      dispatch(me());
+    } catch (authError) {
+      return dispatch(setAuth({ error: authError }));
+    }
+  };
 
 export const logout = () => {
-  window.localStorage.removeItem(TOKEN)
-  history.push('/login')
+  window.localStorage.removeItem(TOKEN);
+  window.localStorage.removeItem('CURRENT_ORDER');
+  history.push('/login');
   return {
     type: SET_AUTH,
-    auth: {}
-  }
-}
+    auth: {},
+  };
+};
 
 /**
  * REDUCER
  */
-export default function(state = {}, action) {
+export default function (state = {}, action) {
   switch (action.type) {
     case SET_AUTH:
-      return action.auth
+      return action.auth;
     default:
-      return state
+      return state;
   }
 }

--- a/client/store/currentOrder.js
+++ b/client/store/currentOrder.js
@@ -16,6 +16,7 @@ export const addToCart = (order, product, userId) => {
     try {
       const productId = product.id;
       const orderId = order.id;
+      console.log(order);
       const potentialCartItem = order.cartItems.find(
         (cartItem) => cartItem.productId === productId
       );
@@ -174,6 +175,30 @@ export const deleteCartItem = (cartItemId, userId) => {
         if (res.status === 204) {
           dispatch(fetchCurrentOrder(userId));
         }
+      }
+    } catch (error) {
+      console.log(error);
+    }
+  };
+};
+
+export const updateQty = (cartItemInfo, userId) => {
+  return async (dispatch) => {
+    try {
+      if (userId) {
+        const { data } = await axios.put(
+          `/api/cartItem/${cartItemInfo.cartItemId}`,
+          { quantity: cartItemInfo.quantity }
+        );
+        dispatch(fetchCurrentOrder(userId));
+      } else {
+        const order = JSON.parse(window.localStorage.getItem('CURRENT_ORDER'));
+        updatedCartItems = order.cartItems.map((cartItem) => {
+          if (cartItem.id === cartItemInfo.id) {
+            cartItemInfo.quantity = cartItemInfo.quantity;
+          }
+        });
+        dispatch(setCurrentOrder(order));
       }
     } catch (error) {
       console.log(error);

--- a/server/api/orders.js
+++ b/server/api/orders.js
@@ -47,7 +47,12 @@ router.get('/:userId/current', async (req, res, next) => {
         },
       },
     });
-    res.send(order);
+    if (order) {
+      res.send(order);
+    } else {
+      const newOrder = await Order.create({ userId: req.params.userId });
+      res.send(newOrder);
+    }
   } catch (error) {
     next(error);
   }

--- a/server/api/orders.js
+++ b/server/api/orders.js
@@ -6,7 +6,9 @@ module.exports = router;
 
 router.get('/:orderId', async (req, res, next) => {
   try {
-    const order = await Order.findByPk(req.params.orderId);
+    const order = await Order.findByPk(req.params.orderId, {
+      include: { model: CartItem, include: { model: Product } },
+    });
     res.send(order);
   } catch (error) {
     next(error);

--- a/server/api/orders.js
+++ b/server/api/orders.js
@@ -48,6 +48,7 @@ router.get('/:userId/current', async (req, res, next) => {
           model: Product,
         },
       },
+      order: [[CartItem, 'id', 'ASC']],
     });
     if (order) {
       res.send(order);


### PR DESCRIPTION
Fixed an issue in the `GET` `/api/orders/:userId/current` route where before it would return an empty string if the user did not have an order, now it creates a new current order and returns it

KEYWORD #5